### PR TITLE
Backend: refactor laji.fi data and cleanup

### DIFF
--- a/app/routes/lajidata.tsx
+++ b/app/routes/lajidata.tsx
@@ -1,5 +1,37 @@
 import { json, LoaderFunction } from "@remix-run/node";
 
+interface Sighting {
+  finnishName: string;
+  latinName: string;
+  sightingTime: Date;
+  coordinates: string;
+  endangerment: string;
+}
+interface LajiApiResponse {
+  results: Array<{
+    unit: {
+      linkings: {
+        taxon: {
+          nameFinnish: string;
+          scientificName: string;
+          latestRedListStatusFinland: string;
+        };
+        originalTaxon: {
+          latestRedListStatusFinland: string;
+        };
+      };
+    };
+    gathering: {
+      displayDateTime: Date;
+    };
+    document: {
+      namedPlace: {
+        wgs84CenterPoint: string;
+      };
+    };
+  }>;
+}
+
 export const loader: LoaderFunction = async ({ request }) => {
   const url = new URL(request.url);
   const bounds = url.searchParams.get("bounds");
@@ -9,7 +41,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     console.error("Missing bounds");
     return json(
       { data: [], message: "Missing required bounds" },
-      { status: 400 }
+      { status: 400 },
     );
   }
   if (!accessToken) {
@@ -45,19 +77,15 @@ export const loader: LoaderFunction = async ({ request }) => {
     access_token: accessToken,
   });
 
-  const api = `https://api.laji.fi/v0/warehouse/query/unit/list?selected=document.namedPlace.wgs84CenterPoint.lat%2Cdocument.namedPlace.wgs84CenterPoint.lon%2Cgathering.displayDateTime%2
-  Cunit.identifications.linkings.taxon.latestRedListStatusFinland.status%2Cunit.identifications.linkings.taxon.latestRedListStatusFinland.year%2
-  Cunit.identifications.linkings.taxon.nameFinnish%2Cunit.linkings.originalTaxon.latestRedListStatusFinland.status%2Cunit.linkings.originalTaxon.latestRedListStatusFinland.year%2
-  Cunit.linkings.taxon.latestRedListStatusFinland.status%2Cunit.linkings.taxon.latestRedListStatusFinland.year%2Cunit.linkings.taxon.nameFinnish%2Cunit.linkings.taxon.scientificName&
-  includeSubTaxa=true&includeNonValidTaxa=true&time=-3653%2F0&${queryParams}`;
+  const api = `https://api.laji.fi/v0/warehouse/query/unit/list?selected=document.namedPlace.wgs84CenterPoint.lat%2Cdocument.namedPlace.wgs84CenterPoint.lon%2Cgathering.displayDateTime%2Cunit.identifications.linkings.taxon.latestRedListStatusFinland.status%2Cunit.identifications.linkings.taxon.latestRedListStatusFinland.year%2Cunit.identifications.linkings.taxon.nameFinnish%2Cunit.linkings.originalTaxon.latestRedListStatusFinland.status%2Cunit.linkings.originalTaxon.latestRedListStatusFinland.year%2Cunit.linkings.taxon.latestRedListStatusFinland.status%2Cunit.linkings.taxon.latestRedListStatusFinland.year%2Cunit.linkings.taxon.nameFinnish%2Cunit.linkings.taxon.scientificName&includeSubTaxa=true&includeNonValidTaxa=true&time=-3653%2F0&${queryParams}`;
 
   try {
     const response = await fetch(api);
     if (!response.ok) {
       throw new Error("Failed to fetch data from Laji API");
     }
-    const data = await response.json();
-    const sightings = data.results.map((item: any) => ({
+    const data: LajiApiResponse = await response.json();
+    const sightings: Sighting[] = data.results.map((item) => ({
       finnishName: item.unit?.linkings?.taxon.nameFinnish,
       latinName: item.unit?.linkings?.taxon?.scientificName,
       sightingTime: item.gathering?.displayDateTime,
@@ -65,12 +93,12 @@ export const loader: LoaderFunction = async ({ request }) => {
       endangerment:
         item.unit?.linkings.originalTaxon.latestRedListStatusFinland,
     }));
-    return sightings;
+    return json({ data: sightings });
   } catch (error) {
     console.error(error);
     return json(
       { data: [], message: "An error occurred while processing the data" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 };

--- a/app/routes/lajidata.tsx
+++ b/app/routes/lajidata.tsx
@@ -9,7 +9,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     console.error("Missing bounds");
     return json(
       { data: [], message: "Missing required bounds" },
-      { status: 400 },
+      { status: 400 }
     );
   }
   if (!accessToken) {
@@ -41,16 +41,36 @@ export const loader: LoaderFunction = async ({ request }) => {
   const queryParams = new URLSearchParams({
     wgs84CenterPoint: `${encodeURIComponent(southLat)}:${encodeURIComponent(northLat)}:${encodeURIComponent(westLng)}:${encodeURIComponent(eastLng)}:WGS84`,
     redListStatusId: "MX.iucnEN,MX.iucnCR,MX.iucnVU,MX.iucnNT",
-    pageSize: "10",
+    pageSize: "1000",
     access_token: accessToken,
   });
 
-  const api = `https://api.laji.fi/v0/warehouse/query/unit/list?${queryParams.toString()}`;
+  const api = `https://api.laji.fi/v0/warehouse/query/unit/list?selected=document.namedPlace.wgs84CenterPoint.lat%2Cdocument.namedPlace.wgs84CenterPoint.lon%2Cgathering.displayDateTime%2
+  Cunit.identifications.linkings.taxon.latestRedListStatusFinland.status%2Cunit.identifications.linkings.taxon.latestRedListStatusFinland.year%2
+  Cunit.identifications.linkings.taxon.nameFinnish%2Cunit.linkings.originalTaxon.latestRedListStatusFinland.status%2Cunit.linkings.originalTaxon.latestRedListStatusFinland.year%2
+  Cunit.linkings.taxon.latestRedListStatusFinland.status%2Cunit.linkings.taxon.latestRedListStatusFinland.year%2Cunit.linkings.taxon.nameFinnish%2Cunit.linkings.taxon.scientificName&
+  includeSubTaxa=true&includeNonValidTaxa=true&time=-3653%2F0&${queryParams}`;
 
-  return fetch(api).then((response) => {
+  try {
+    const response = await fetch(api);
     if (!response.ok) {
       throw new Error("Failed to fetch data from Laji API");
     }
-    return response;
-  });
+    const data = await response.json();
+    const sightings = data.results.map((item: any) => ({
+      finnishName: item.unit?.linkings?.taxon.nameFinnish,
+      latinName: item.unit?.linkings?.taxon?.scientificName,
+      sightingTime: item.gathering?.displayDateTime,
+      coordinates: item.document?.namedPlace.wgs84CenterPoint,
+      endangerment:
+        item.unit?.linkings.originalTaxon.latestRedListStatusFinland,
+    }));
+    return sightings;
+  } catch (error) {
+    console.error(error);
+    return json(
+      { data: [], message: "An error occurred while processing the data" },
+      { status: 500 }
+    );
+  }
 };


### PR DESCRIPTION
Now fetches only max 10 year old data from api.laji.fi and returns the finnish names, latin names, sighting time, coordinates and endangerment status.