### PR TITLE
Menu component for UI

### DIFF
--- a/app/components/controls/Controls.tsx
+++ b/app/components/controls/Controls.tsx
@@ -39,7 +39,7 @@ export default function Controls({
 }: FabsProps & ControlsProps) {
   // Uses current day by default
   const [sliderValue, setSliderValue] = useState<number | number[]>(
-    dayjs().valueOf()
+    dayjs().valueOf(),
   );
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const theme = useTheme();
@@ -68,7 +68,7 @@ export default function Controls({
           setEndDate(dayjs(value));
         }
       }, 400),
-    [setEndDate, setStartDate]
+    [setEndDate, setStartDate],
   );
 
   const handleSliderChange = (event: Event, value: number | number[]) => {

--- a/app/components/controls/Controls.tsx
+++ b/app/components/controls/Controls.tsx
@@ -40,7 +40,7 @@ export default function Controls({
 }: FabsProps & ControlsProps) {
   // Uses current day by default
   const [sliderValue, setSliderValue] = useState<number | number[]>(
-    dayjs().valueOf()
+    dayjs().valueOf(),
   );
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const theme = useTheme();
@@ -69,7 +69,7 @@ export default function Controls({
           setEndDate(dayjs(value));
         }
       }, 400),
-    [setEndDate, setStartDate]
+    [setEndDate, setStartDate],
   );
 
   const handleSliderChange = (event: Event, value: number | number[]) => {

--- a/app/components/controls/Controls.tsx
+++ b/app/components/controls/Controls.tsx
@@ -22,6 +22,8 @@ export interface ControlsProps {
   setStartDate: (v: Dayjs) => void;
   setEndDate: (v: Dayjs) => void;
   isDrawerOpen: boolean;
+  startDate: Dayjs;
+  endDate: Dayjs;
 }
 
 export default function Controls({
@@ -33,10 +35,12 @@ export default function Controls({
   setStartDate,
   setEndDate,
   onAddClick,
+  startDate,
+  endDate,
 }: FabsProps & ControlsProps) {
   // Uses current day by default
   const [sliderValue, setSliderValue] = useState<number | number[]>(
-    dayjs().valueOf(),
+    dayjs().valueOf()
   );
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const theme = useTheme();
@@ -65,7 +69,7 @@ export default function Controls({
           setEndDate(dayjs(value));
         }
       }, 400),
-    [setEndDate, setStartDate],
+    [setEndDate, setStartDate]
   );
 
   const handleSliderChange = (event: Event, value: number | number[]) => {
@@ -79,6 +83,10 @@ export default function Controls({
         isDrawerOpen={isDrawerOpen}
         setIsDrawerOpen={setIsDrawerOpen}
         isMobile={isMobile}
+        setStartDate={setStartDate}
+        setEndDate={setEndDate}
+        startDate={startDate}
+        endDate={endDate}
       />
       <SearchBar isDrawerOpen={isDrawerOpen} isMobile={isMobile} />
       <StyledContainer maxWidth={false}>
@@ -93,8 +101,8 @@ export default function Controls({
           <DateSlider
             value={sliderValue}
             onChange={handleSliderChange}
-            min={period.start.valueOf()}
-            max={period.end.valueOf()}
+            min={startDate.valueOf()}
+            max={endDate.valueOf()}
           />
         )}
       </StyledContainer>

--- a/app/components/controls/Controls.tsx
+++ b/app/components/controls/Controls.tsx
@@ -1,9 +1,16 @@
-import { Container, debounce, styled } from "@mui/material";
+import {
+  Container,
+  debounce,
+  styled,
+  useTheme,
+  useMediaQuery,
+} from "@mui/material";
 import SearchBar from "./searchbar/SearchBar";
 import Fabs, { type FabsProps } from "./fabs/Fabs";
 import DateSlider from "./slider/DateSlider";
 import { useMemo, useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
+import MenuDrawer from "./drawer/Drawer";
 
 export interface Period {
   start: Dayjs;
@@ -14,6 +21,7 @@ export interface ControlsProps {
   period: Period;
   setStartDate: (v: Dayjs) => void;
   setEndDate: (v: Dayjs) => void;
+  isDrawerOpen: boolean;
 }
 
 export default function Controls({
@@ -30,6 +38,9 @@ export default function Controls({
   const [sliderValue, setSliderValue] = useState<number | number[]>(
     dayjs().valueOf(),
   );
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   const StyledContainer = styled(Container)({
     position: "absolute",
@@ -64,7 +75,12 @@ export default function Controls({
 
   return (
     <Container>
-      <SearchBar />
+      <MenuDrawer
+        isDrawerOpen={isDrawerOpen}
+        setIsDrawerOpen={setIsDrawerOpen}
+        isMobile={isMobile}
+      />
+      <SearchBar isDrawerOpen={isDrawerOpen} isMobile={isMobile} />
       <StyledContainer maxWidth={false}>
         <Fabs
           satelliteViewOpen={satelliteViewOpen}

--- a/app/components/controls/Controls.tsx
+++ b/app/components/controls/Controls.tsx
@@ -19,8 +19,8 @@ export interface Period {
 
 export interface ControlsProps {
   period: Period;
-  setStartDate: (v: Dayjs) => void;
-  setEndDate: (v: Dayjs) => void;
+  setStartDate: (v: Dayjs | null) => void;
+  setEndDate: (v: Dayjs | null) => void;
   isDrawerOpen: boolean;
   startDate: Dayjs;
   endDate: Dayjs;
@@ -31,7 +31,6 @@ export default function Controls({
   setSatelliteViewOpen,
   comparisonViewOpen,
   setComparisonViewOpen,
-  period,
   setStartDate,
   setEndDate,
   onAddClick,
@@ -40,7 +39,7 @@ export default function Controls({
 }: FabsProps & ControlsProps) {
   // Uses current day by default
   const [sliderValue, setSliderValue] = useState<number | number[]>(
-    dayjs().valueOf(),
+    dayjs().valueOf()
   );
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const theme = useTheme();
@@ -69,7 +68,7 @@ export default function Controls({
           setEndDate(dayjs(value));
         }
       }, 400),
-    [setEndDate, setStartDate],
+    [setEndDate, setStartDate]
   );
 
   const handleSliderChange = (event: Event, value: number | number[]) => {

--- a/app/components/controls/Controls.tsx
+++ b/app/components/controls/Controls.tsx
@@ -12,13 +12,7 @@ import { useMemo, useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
 import MenuDrawer from "./drawer/Drawer";
 
-export interface Period {
-  start: Dayjs;
-  end: Dayjs;
-}
-
 export interface ControlsProps {
-  period: Period;
   setStartDate: (v: Dayjs | null) => void;
   setEndDate: (v: Dayjs | null) => void;
   isDrawerOpen: boolean;

--- a/app/components/controls/datePickers/DatePickers.tsx
+++ b/app/components/controls/datePickers/DatePickers.tsx
@@ -27,7 +27,7 @@ export default function DatePickers({
     setStartDate(newValue);
     if (newValue && endDate && newValue.isAfter(endDate)) {
       setStartDateError(
-        "Aloituspäivä ei voi olla myöhemmin kuin vertailtava päivä"
+        "Aloituspäivä ei voi olla myöhemmin kuin vertailtava päivä",
       );
     } else {
       setStartDateError(null);
@@ -39,7 +39,7 @@ export default function DatePickers({
     setEndDate(newValue);
     if (startDate && newValue && newValue.isBefore(startDate)) {
       setEndDateError(
-        "Vertailtava päivä ei voi olla aikaisemmin kuin aloitupäivä"
+        "Vertailtava päivä ei voi olla aikaisemmin kuin aloitupäivä",
       );
     } else {
       setStartDateError(null);

--- a/app/components/controls/datePickers/DatePickers.tsx
+++ b/app/components/controls/datePickers/DatePickers.tsx
@@ -1,0 +1,97 @@
+import { Box, Typography } from "@mui/material";
+import { useState } from "react";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { Dayjs } from "dayjs";
+import { fiFI } from "@mui/x-date-pickers/locales";
+import "dayjs/locale/fi";
+
+interface DatePickersProps {
+  setStartDate: (date: Dayjs | null) => void;
+  setEndDate: (date: Dayjs | null) => void;
+  startDate: Dayjs | null;
+  endDate: Dayjs | null;
+}
+
+export default function DatePickers({
+  setStartDate,
+  setEndDate,
+  startDate,
+  endDate,
+}: DatePickersProps) {
+  const [startDateError, setStartDateError] = useState<string | null>(null);
+  const [endDateError, setEndDateError] = useState<string | null>(null);
+
+  const handleStartDateChange = (newValue: Dayjs | null) => {
+    setStartDate(newValue);
+    if (newValue && endDate && newValue.isAfter(endDate)) {
+      setStartDateError(
+        "Aloituspäivä ei voi olla myöhemmin kuin vertailtava päivä"
+      );
+    } else {
+      setStartDateError(null);
+      setEndDateError(null);
+    }
+  };
+
+  const handleEndDateChange = (newValue: Dayjs | null) => {
+    setEndDate(newValue);
+    if (startDate && newValue && newValue.isBefore(startDate)) {
+      setEndDateError(
+        "Vertailtava päivä ei voi olla aikaisemmin kuin aloitupäivä"
+      );
+    } else {
+      setStartDateError(null);
+      setEndDateError(null);
+    }
+  };
+
+  return (
+    <LocalizationProvider
+      dateAdapter={AdapterDayjs}
+      adapterLocale="fi"
+      localeText={
+        fiFI.components.MuiLocalizationProvider.defaultProps.localeText
+      }
+    >
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+          width: "100%",
+          margin: "5% auto",
+        }}
+      >
+        <Typography variant="h6">Kuvien vertailu</Typography>
+        <DatePicker
+          value={startDate}
+          label="Ensimmäinen päivämäärä"
+          onChange={handleStartDateChange}
+          format="DD/MM/YYYY"
+          slotProps={{
+            textField: {
+              fullWidth: true,
+              error: !!startDateError,
+              helperText: startDateError,
+            },
+          }}
+        />
+        <DatePicker
+          value={endDate}
+          label="Toinen päivämäärä"
+          onChange={handleEndDateChange}
+          format="DD/MM/YYYY"
+          slotProps={{
+            textField: {
+              fullWidth: true,
+              error: !!endDateError,
+              helperText: endDateError,
+            },
+          }}
+        />
+      </Box>
+    </LocalizationProvider>
+  );
+}

--- a/app/components/controls/drawer/Drawer.tsx
+++ b/app/components/controls/drawer/Drawer.tsx
@@ -1,0 +1,72 @@
+import {
+    Drawer,
+    styled,
+    IconButton,
+    useMediaQuery,
+    useTheme,
+} from "@mui/material";
+import MenuIcon from "@mui/icons-material/MenuOutlined";
+import { useState } from "react";
+
+const DrawerContainer = styled("div")(({ theme }) => ({
+    position: "absolute",
+    zIndex: 1000,
+    [theme.breakpoints.down("sm")]: {
+        left: "50%",
+        bottom: theme.spacing(2),
+        transform: "translateX(-50%)",
+    },
+    [theme.breakpoints.up("md")]: {
+        left: theme.spacing(2),
+        top: "50%",
+        transform: "translateY(-50%)",
+    },
+}));
+
+const ButtonContainer = styled("div")({
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+});
+
+export default function MenuDrawer() {
+    const [drawerOpen, setDrawerOpen] = useState(false);
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
+    const toggleDrawer = (open: boolean) => () => {
+        setDrawerOpen(open);
+    };
+    return (
+        <DrawerContainer>
+            {/* TODO remove this demo button that opens the drawer */}
+            <ButtonContainer>
+                <IconButton
+                    onClick={toggleDrawer(true)}
+                    color="primary"
+                    sx={{
+                        width: 56,
+                        height: 56,
+                        borderRadius: "50%",
+                        backgroundColor: "primary.main",
+                        "&:hover": {
+                            backgroundColor: "primary.dark",
+                        },
+                    }}
+                >
+                    <MenuIcon />
+                </IconButton>
+            </ButtonContainer>
+            <Drawer
+                anchor={isMobile ? "bottom" : "left"}
+                open={drawerOpen}
+                onClose={toggleDrawer(false)}
+            >
+                <div style={{ width: isMobile ? "100%" : 250, padding: 16 }}>
+                    <h3>Menu</h3>
+                    <p>Drawer Content</p>
+                </div>
+            </Drawer>
+        </DrawerContainer>
+    );
+}

--- a/app/components/controls/drawer/Drawer.tsx
+++ b/app/components/controls/drawer/Drawer.tsx
@@ -1,48 +1,58 @@
 import {
     Drawer,
     styled,
+    Box,
     IconButton,
     useMediaQuery,
     useTheme,
+    List,
 } from "@mui/material";
 import MenuIcon from "@mui/icons-material/MenuOutlined";
+import CloseIcon from "@mui/icons-material/Close";
 import { useState } from "react";
 
-const DrawerContainer = styled("div")(({ theme }) => ({
-    position: "absolute",
-    zIndex: 1000,
+//TODO descide the correct width of drawer
+const DrawerWidth = 250;
+
+//TODO to be removed once the correct opening logic is implemented
+//Button container for the temporary opening logic for the drawer
+const ButtonContainer = styled("div")(({ theme }) => ({
+    position: "fixed",
+    zIndex: 900,
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
     [theme.breakpoints.down("sm")]: {
         left: "50%",
         bottom: theme.spacing(2),
         transform: "translateX(-50%)",
     },
-    [theme.breakpoints.up("md")]: {
+    [theme.breakpoints.up("sm")]: {
         left: theme.spacing(2),
         top: "50%",
         transform: "translateY(-50%)",
     },
 }));
 
-const ButtonContainer = styled("div")({
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-});
-
 export default function MenuDrawer() {
-    const [drawerOpen, setDrawerOpen] = useState(false);
+    /**
+     * TODO isDrawerOpen and toggleDrawer propably need to be moved to a parent component
+     * once additional logic is implemented for drawer opening, like satellite comparison
+     */
+    const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+    // Toggle function to open/close the drawer
+    const toggleDrawer = (open: boolean) => {
+        setIsDrawerOpen(open);
+    };
+
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
-    const toggleDrawer = (open: boolean) => () => {
-        setDrawerOpen(open);
-    };
     return (
-        <DrawerContainer>
-            {/* TODO remove this demo button that opens the drawer */}
+        <>
             <ButtonContainer>
                 <IconButton
-                    onClick={toggleDrawer(true)}
+                    onClick={() => toggleDrawer(true)}
                     color="primary"
                     sx={{
                         width: 56,
@@ -57,16 +67,42 @@ export default function MenuDrawer() {
                     <MenuIcon />
                 </IconButton>
             </ButtonContainer>
+
             <Drawer
+                variant="persistent"
                 anchor={isMobile ? "bottom" : "left"}
-                open={drawerOpen}
-                onClose={toggleDrawer(false)}
+                open={isDrawerOpen}
+                sx={{
+                    "& .MuiDrawer-paper": {
+                        width: isMobile ? "100%" : DrawerWidth,
+                        height: isMobile ? "50%" : "100vh", //TODO decide the drawer height on mobile
+                        bottom: isMobile ? 0 : "unset",
+                        left: isMobile ? "unset" : 0,
+                    },
+                }}
             >
-                <div style={{ width: isMobile ? "100%" : 250, padding: 16 }}>
+                <Box
+                    sx={{
+                        padding: 2,
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "flex-start",
+                    }}
+                >
+                    <IconButton
+                        onClick={() => toggleDrawer(false)}
+                        sx={{
+                            alignSelf: "flex-end",
+                            marginBottom: 2,
+                        }}
+                    >
+                        <CloseIcon />
+                    </IconButton>
+
                     <h3>Menu</h3>
                     <p>Drawer Content</p>
-                </div>
+                </Box>
             </Drawer>
-        </DrawerContainer>
+        </>
     );
 }

--- a/app/components/controls/drawer/Drawer.tsx
+++ b/app/components/controls/drawer/Drawer.tsx
@@ -9,6 +9,8 @@ import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import DragHandleRoundedIcon from "@mui/icons-material/DragHandleRounded";
 import { useMap } from "react-leaflet";
 import LayerControl from "../layerControl/LayerControl";
+import DatePickers from "../datePickers/DatePickers";
+import { Dayjs } from "dayjs";
 
 const DrawerWidth = 250;
 const drawerBleeding = 60;
@@ -31,12 +33,20 @@ interface MenuDrawerProps {
   isDrawerOpen: boolean;
   setIsDrawerOpen: (open: boolean) => void;
   isMobile: boolean;
+  setStartDate: (date: Dayjs | null) => void;
+  setEndDate: (date: Dayjs | null) => void;
+  startDate: Dayjs;
+  endDate: Dayjs;
 }
 
 export default function MenuDrawer({
   isDrawerOpen,
   setIsDrawerOpen,
   isMobile,
+  setStartDate,
+  setEndDate,
+  startDate,
+  endDate,
 }: MenuDrawerProps) {
   // Toggle function to open/close the drawer
   const toggleDrawer = () => {
@@ -86,6 +96,12 @@ export default function MenuDrawer({
             <DragHandleRoundedIcon />
           </Box>
           <Box sx={{ padding: 2, height: "100%" }}>
+            <DatePickers
+              setStartDate={setStartDate}
+              setEndDate={setEndDate}
+              startDate={startDate}
+              endDate={endDate}
+            />
             <LayerControl />
           </Box>
         </SwipeableDrawerStyled>
@@ -135,6 +151,12 @@ export default function MenuDrawer({
               alignItems: "flex-start",
             }}
           >
+            <DatePickers
+              setStartDate={setStartDate}
+              setEndDate={setEndDate}
+              startDate={startDate}
+              endDate={endDate}
+            />
             <LayerControl />
           </Box>
         </SwipeableDrawerStyledDesktop>

--- a/app/components/controls/drawer/Drawer.tsx
+++ b/app/components/controls/drawer/Drawer.tsx
@@ -1,5 +1,6 @@
 import {
     Drawer,
+    SwipeableDrawer,
     styled,
     Box,
     IconButton,
@@ -10,15 +11,17 @@ import {
 import MenuIcon from "@mui/icons-material/MenuOutlined";
 import CloseIcon from "@mui/icons-material/Close";
 import { useState } from "react";
+import { useMap } from "react-leaflet";
+import LayerControl from "../layerControl/LayerControl";
 
-//TODO descide the correct width of drawer
+//TODO decide the correct width of drawer
 const DrawerWidth = 250;
 
-//TODO to be removed once the correct opening logic is implemented
+//TODO refactor to a better menu opening button
 //Button container for the temporary opening logic for the drawer
 const ButtonContainer = styled("div")(({ theme }) => ({
     position: "fixed",
-    zIndex: 900,
+    zIndex: 1200,
     display: "flex",
     justifyContent: "center",
     alignItems: "center",
@@ -34,19 +37,26 @@ const ButtonContainer = styled("div")(({ theme }) => ({
     },
 }));
 
-export default function MenuDrawer() {
-    /**
-     * TODO isDrawerOpen and toggleDrawer propably need to be moved to a parent component
-     * once additional logic is implemented for drawer opening, like satellite comparison
-     */
-    const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+interface MenuDrawerProps {
+    isDrawerOpen: boolean;
+    setIsDrawerOpen: (open: boolean) => void;
+    isMobile: boolean;
+}
+
+export default function MenuDrawer({
+    isDrawerOpen,
+    setIsDrawerOpen,
+    isMobile,
+}: MenuDrawerProps) {
     // Toggle function to open/close the drawer
     const toggleDrawer = (open: boolean) => {
         setIsDrawerOpen(open);
     };
 
-    const theme = useTheme();
-    const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+    // Handling the map drag when menu open
+    const map = useMap();
+    const stopMapDrag = () => map.dragging.disable();
+    const startMapDrag = () => map.dragging.enable();
 
     return (
         <>
@@ -72,6 +82,10 @@ export default function MenuDrawer() {
                 variant="persistent"
                 anchor={isMobile ? "bottom" : "left"}
                 open={isDrawerOpen}
+                onMouseDown={stopMapDrag}
+                onMouseUp={startMapDrag}
+                onTouchStart={stopMapDrag}
+                onTouchEnd={startMapDrag}
                 sx={{
                     "& .MuiDrawer-paper": {
                         width: isMobile ? "100%" : DrawerWidth,
@@ -99,8 +113,7 @@ export default function MenuDrawer() {
                         <CloseIcon />
                     </IconButton>
 
-                    <h3>Menu</h3>
-                    <p>Drawer Content</p>
+                    <LayerControl />
                 </Box>
             </Drawer>
         </>

--- a/app/components/controls/drawer/Drawer.tsx
+++ b/app/components/controls/drawer/Drawer.tsx
@@ -1,121 +1,144 @@
 import {
-    Drawer,
-    SwipeableDrawer,
-    styled,
-    Box,
-    IconButton,
-    useMediaQuery,
-    useTheme,
-    List,
+  Drawer,
+  SwipeableDrawer,
+  styled,
+  Box,
+  IconButton,
 } from "@mui/material";
-import MenuIcon from "@mui/icons-material/MenuOutlined";
-import CloseIcon from "@mui/icons-material/Close";
-import { useState } from "react";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+import DragHandleRoundedIcon from "@mui/icons-material/DragHandleRounded";
 import { useMap } from "react-leaflet";
 import LayerControl from "../layerControl/LayerControl";
 
-//TODO decide the correct width of drawer
 const DrawerWidth = 250;
+const drawerBleeding = 60;
 
-//TODO refactor to a better menu opening button
-//Button container for the temporary opening logic for the drawer
-const ButtonContainer = styled("div")(({ theme }) => ({
-    position: "fixed",
-    zIndex: 1200,
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    [theme.breakpoints.down("sm")]: {
-        left: "50%",
-        bottom: theme.spacing(2),
-        transform: "translateX(-50%)",
-    },
-    [theme.breakpoints.up("sm")]: {
-        left: theme.spacing(2),
-        top: "50%",
-        transform: "translateY(-50%)",
-    },
+//mobile drawer
+const SwipeableDrawerStyled = styled(SwipeableDrawer)(() => ({
+  "& .MuiDrawer-paper": {
+    overflowY: "visible",
+  },
+}));
+
+// desktop drawer
+const SwipeableDrawerStyledDesktop = styled(Drawer)(() => ({
+  "& .MuiDrawer-paper": {
+    overflowY: "visible",
+  },
 }));
 
 interface MenuDrawerProps {
-    isDrawerOpen: boolean;
-    setIsDrawerOpen: (open: boolean) => void;
-    isMobile: boolean;
+  isDrawerOpen: boolean;
+  setIsDrawerOpen: (open: boolean) => void;
+  isMobile: boolean;
 }
 
 export default function MenuDrawer({
-    isDrawerOpen,
-    setIsDrawerOpen,
-    isMobile,
+  isDrawerOpen,
+  setIsDrawerOpen,
+  isMobile,
 }: MenuDrawerProps) {
-    // Toggle function to open/close the drawer
-    const toggleDrawer = (open: boolean) => {
-        setIsDrawerOpen(open);
-    };
+  // Toggle function to open/close the drawer
+  const toggleDrawer = () => {
+    setIsDrawerOpen(!isDrawerOpen);
+  };
 
-    // Handling the map drag when menu open
-    const map = useMap();
-    const stopMapDrag = () => map.dragging.disable();
-    const startMapDrag = () => map.dragging.enable();
+  // Handling the map drag when menu open
+  const map = useMap();
+  const stopMapDrag = () => map.dragging.disable();
+  const startMapDrag = () => map.dragging.enable();
 
-    return (
-        <>
-            <ButtonContainer>
-                <IconButton
-                    onClick={() => toggleDrawer(true)}
-                    color="primary"
-                    sx={{
-                        width: 56,
-                        height: 56,
-                        borderRadius: "50%",
-                        backgroundColor: "primary.main",
-                        "&:hover": {
-                            backgroundColor: "primary.dark",
-                        },
-                    }}
-                >
-                    <MenuIcon />
-                </IconButton>
-            </ButtonContainer>
+  return (
+    <>
+      {isMobile ? (
+        <SwipeableDrawerStyled
+          anchor="bottom"
+          open={isDrawerOpen}
+          onClose={() => toggleDrawer()}
+          onOpen={() => toggleDrawer()}
+          swipeAreaWidth={drawerBleeding}
+          disableSwipeToOpen={false}
+          ModalProps={{ keepMounted: true }}
+          onMouseDown={stopMapDrag}
+          onMouseUp={startMapDrag}
+          onTouchStart={stopMapDrag}
+          onTouchEnd={startMapDrag}
+          sx={{
+            "& .MuiDrawer-paper": {
+              height: "50%",
+            },
+          }}
+        >
+          <Box
+            sx={{
+              position: "absolute",
+              top: -drawerBleeding / 2,
+              right: 0,
+              left: 0,
+              height: drawerBleeding,
+              backgroundColor: "background.paper",
+              textAlign: "center",
+              visibility: "visible",
+              borderTopLeftRadius: 10,
+              borderTopRightRadius: 10,
+            }}
+          >
+            <DragHandleRoundedIcon />
+          </Box>
+          <Box sx={{ padding: 2, height: "100%" }}>
+            <LayerControl />
+          </Box>
+        </SwipeableDrawerStyled>
+      ) : (
+        <SwipeableDrawerStyledDesktop
+          variant="persistent"
+          anchor="left"
+          open={isDrawerOpen}
+          sx={{
+            "& .MuiDrawer-paper": {
+              width: DrawerWidth,
+              height: "100vh",
+            },
+          }}
+          onMouseDown={stopMapDrag}
+          onMouseUp={startMapDrag}
+          onTouchStart={stopMapDrag}
+          onTouchEnd={startMapDrag}
+        >
+          <Box
+            sx={{
+              position: "absolute",
+              top: "50%",
+              right: -40,
+              width: 40,
+              height: "20%",
+              backgroundColor: "background.paper",
+              visibility: "visible",
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              borderTopRightRadius: 15,
+              borderBottomRightRadius: 15,
+              transform: "translateY(-50%)",
+            }}
+          >
+            <IconButton onClick={() => toggleDrawer()}>
+              <DragIndicatorIcon />
+            </IconButton>
+          </Box>
 
-            <Drawer
-                variant="persistent"
-                anchor={isMobile ? "bottom" : "left"}
-                open={isDrawerOpen}
-                onMouseDown={stopMapDrag}
-                onMouseUp={startMapDrag}
-                onTouchStart={stopMapDrag}
-                onTouchEnd={startMapDrag}
-                sx={{
-                    "& .MuiDrawer-paper": {
-                        width: isMobile ? "100%" : DrawerWidth,
-                        height: isMobile ? "50%" : "100vh", //TODO decide the drawer height on mobile
-                        bottom: isMobile ? 0 : "unset",
-                        left: isMobile ? "unset" : 0,
-                    },
-                }}
-            >
-                <Box
-                    sx={{
-                        padding: 2,
-                        display: "flex",
-                        flexDirection: "column",
-                        alignItems: "flex-start",
-                    }}
-                >
-                    <IconButton
-                        onClick={() => toggleDrawer(false)}
-                        sx={{
-                            alignSelf: "flex-end",
-                            marginBottom: 2,
-                        }}
-                    >
-                        <CloseIcon />
-                    </IconButton>
-
-                    <LayerControl />
-                </Box>
-            </Drawer>
-        </>
-    );
+          <Box
+            sx={{
+              padding: 2,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "flex-start",
+            }}
+          >
+            <LayerControl />
+          </Box>
+        </SwipeableDrawerStyledDesktop>
+      )}
+    </>
+  );
 }

--- a/app/components/controls/layerControl/LayerControl.tsx
+++ b/app/components/controls/layerControl/LayerControl.tsx
@@ -3,60 +3,55 @@ import { List, ListItem, Checkbox, Box, Typography } from "@mui/material";
 
 // Mock data: array of layer options
 const layerOptions = [
-    { key: "conservation", name: "Conservation Layer" },
-    { key: "reports", name: "Reports Layer" },
-    { key: "species", name: "Species Layer" },
+  { key: "sightings", name: "Uhanalaislajihavainnot" },
+  { key: "observations", name: "Käyttäjähavainnot" },
+  { key: "conservation", name: "Suojelualueet" },
 ] as const;
 
 type LayerKey = (typeof layerOptions)[number]["key"];
 
 export default function LayerControl() {
-    const [checkedLayers, setCheckedLayers] = useState<
-        Record<LayerKey, boolean>
-    >({
-        conservation: false,
-        reports: false,
-        species: false,
-    });
+  //TODO move this to the map component
+  const [overlayVisibility, setOverlayVisibility] = useState<
+    Record<LayerKey, boolean>
+  >({
+    sightings: false,
+    observations: false,
+    conservation: false,
+  });
 
-    // Toggle layer
-    const handleCheckboxChange = (key: LayerKey) => {
-        setCheckedLayers((prevState) => ({
-            ...prevState,
-            [key]: !prevState[key],
-        }));
-    };
+  // Toggle layer
+  const handleCheckboxChange = (key: LayerKey) => {
+    setOverlayVisibility((prevState) => ({
+      ...prevState,
+      [key]: !prevState[key],
+    }));
+  };
 
-    return (
-        <Box
+  return (
+    <Box>
+      <Typography variant="h6" sx={{ mb: 1 }}>
+        Kartan tasot
+      </Typography>
+      <List sx={{ padding: 0 }}>
+        {layerOptions.map((layer) => (
+          <ListItem
+            key={layer.key}
             sx={{
-                width: 200,
-                padding: 1,
-                borderRadius: 2,
+              padding: "4px 0px",
+              display: "flex",
+              alignItems: "center",
             }}
-        >
-            <Typography variant="subtitle1" sx={{ mb: 1 }}>
-                Layers
-            </Typography>
-            <List sx={{ padding: 0 }}>
-                {layerOptions.map((layer) => (
-                    <ListItem
-                        key={layer.key}
-                        sx={{
-                            padding: "4px 8px",
-                            display: "flex",
-                            alignItems: "center",
-                        }}
-                    >
-                        <Checkbox
-                            size="small"
-                            checked={checkedLayers[layer.key]}
-                            onChange={() => handleCheckboxChange(layer.key)}
-                        />
-                        <Typography variant="body2">{layer.name}</Typography>
-                    </ListItem>
-                ))}
-            </List>
-        </Box>
-    );
+          >
+            <Checkbox
+              size="small"
+              checked={overlayVisibility[layer.key]}
+              onChange={() => handleCheckboxChange(layer.key)}
+            />
+            <Typography variant="body2">{layer.name}</Typography>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
 }

--- a/app/components/controls/layerControl/LayerControl.tsx
+++ b/app/components/controls/layerControl/LayerControl.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { List, ListItem, Checkbox, Box, Typography } from "@mui/material";
+
+// Mock data: array of layer options
+const layerOptions = [
+    { key: "conservation", name: "Conservation Layer" },
+    { key: "reports", name: "Reports Layer" },
+    { key: "species", name: "Species Layer" },
+] as const;
+
+type LayerKey = (typeof layerOptions)[number]["key"];
+
+export default function LayerControl() {
+    const [checkedLayers, setCheckedLayers] = useState<
+        Record<LayerKey, boolean>
+    >({
+        conservation: false,
+        reports: false,
+        species: false,
+    });
+
+    // Toggle layer
+    const handleCheckboxChange = (key: LayerKey) => {
+        setCheckedLayers((prevState) => ({
+            ...prevState,
+            [key]: !prevState[key],
+        }));
+    };
+
+    return (
+        <Box
+            sx={{
+                width: 200,
+                padding: 1,
+                borderRadius: 2,
+            }}
+        >
+            <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                Layers
+            </Typography>
+            <List sx={{ padding: 0 }}>
+                {layerOptions.map((layer) => (
+                    <ListItem
+                        key={layer.key}
+                        sx={{
+                            padding: "4px 8px",
+                            display: "flex",
+                            alignItems: "center",
+                        }}
+                    >
+                        <Checkbox
+                            size="small"
+                            checked={checkedLayers[layer.key]}
+                            onChange={() => handleCheckboxChange(layer.key)}
+                        />
+                        <Typography variant="body2">{layer.name}</Typography>
+                    </ListItem>
+                ))}
+            </List>
+        </Box>
+    );
+}

--- a/app/components/controls/searchbar/SearchBar.tsx
+++ b/app/components/controls/searchbar/SearchBar.tsx
@@ -4,6 +4,7 @@ import {
   Paper,
   styled,
   TextField,
+  useTheme,
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import { useEffect, useMemo, useState } from "react";
@@ -55,7 +56,10 @@ function LocationSearch() {
           request: { input: string },
           callback: (results?: readonly Location[]) => void,
         ) => {
-          const params = new URLSearchParams({ q: request.input, limit: "10" });
+          const params = new URLSearchParams({
+            q: request.input,
+            limit: "10",
+          });
           // Fetch requested locations using the GISCO API.
           fetch(`https://gisco-services.ec.europa.eu/api/?${params}`)
             .then((response) => response.json())
@@ -159,11 +163,22 @@ function LocationSearch() {
   );
 }
 
-export default function SearchBar() {
+interface SearchBarProps {
+  isDrawerOpen: boolean;
+  isMobile: boolean;
+}
+
+export default function SearchBar({ isDrawerOpen, isMobile }: SearchBarProps) {
+  const theme = useTheme();
+
   const StyledPaper = styled(Paper)({
     position: "absolute",
     top: "0.7rem",
-    left: "0.7rem",
+    left: isMobile || !isDrawerOpen ? "0.7rem" : `${250 + theme.spacing(1)}px`, // 250 = drawer width
+    width:
+      isMobile || !isDrawerOpen
+        ? "calc(100% - 1.4rem)"
+        : `calc(100% - ${250 + 16}px)`, // Subtract drawer width + margins
     right: "0.7rem",
     zIndex: 1000,
   });

--- a/app/components/controls/searchbar/SearchBar.tsx
+++ b/app/components/controls/searchbar/SearchBar.tsx
@@ -54,7 +54,7 @@ function LocationSearch() {
       debounce(
         (
           request: { input: string },
-          callback: (results?: readonly Location[]) => void,
+          callback: (results?: readonly Location[]) => void
         ) => {
           const params = new URLSearchParams({
             q: request.input,
@@ -70,20 +70,20 @@ function LocationSearch() {
                 lat: geometry.coordinates[1],
                 id: properties.osm_id,
                 name: properties.name,
-              })),
+              }))
             )
             // Filter out duplicate results.
             .then((result) =>
               result.filter(
                 ({ id: filterId }, index, arr) =>
-                  arr.findIndex(({ id }) => id === filterId) === index,
-              ),
+                  arr.findIndex(({ id }) => id === filterId) === index
+              )
             )
             .then(callback);
         },
-        400,
+        400
       ),
-    [],
+    []
   );
 
   useEffect(() => {
@@ -131,7 +131,7 @@ function LocationSearch() {
         if (newValue)
           map.panTo(
             { lat: newValue.lat, lng: newValue.lng },
-            { animate: true },
+            { animate: true }
           );
       }}
       onInputChange={(_, newInput) => setInput(newInput)}
@@ -174,7 +174,7 @@ export default function SearchBar({ isDrawerOpen, isMobile }: SearchBarProps) {
   const StyledPaper = styled(Paper)({
     position: "absolute",
     top: "0.7rem",
-    left: isMobile || !isDrawerOpen ? "0.7rem" : `${250 + theme.spacing(1)}px`, // 250 = drawer width
+    left: isMobile || !isDrawerOpen ? "0.7rem" : `${250 + theme.spacing(1)}px`, // 250 + 50 = drawer+bleeding width
     width:
       isMobile || !isDrawerOpen
         ? "calc(100% - 1.4rem)"

--- a/app/components/controls/searchbar/SearchBar.tsx
+++ b/app/components/controls/searchbar/SearchBar.tsx
@@ -54,7 +54,7 @@ function LocationSearch() {
       debounce(
         (
           request: { input: string },
-          callback: (results?: readonly Location[]) => void
+          callback: (results?: readonly Location[]) => void,
         ) => {
           const params = new URLSearchParams({
             q: request.input,
@@ -70,20 +70,20 @@ function LocationSearch() {
                 lat: geometry.coordinates[1],
                 id: properties.osm_id,
                 name: properties.name,
-              }))
+              })),
             )
             // Filter out duplicate results.
             .then((result) =>
               result.filter(
                 ({ id: filterId }, index, arr) =>
-                  arr.findIndex(({ id }) => id === filterId) === index
-              )
+                  arr.findIndex(({ id }) => id === filterId) === index,
+              ),
             )
             .then(callback);
         },
-        400
+        400,
       ),
-    []
+    [],
   );
 
   useEffect(() => {
@@ -131,7 +131,7 @@ function LocationSearch() {
         if (newValue)
           map.panTo(
             { lat: newValue.lat, lng: newValue.lng },
-            { animate: true }
+            { animate: true },
           );
       }}
       onInputChange={(_, newInput) => setInput(newInput)}

--- a/app/components/map/_MapComponent.client.tsx
+++ b/app/components/map/_MapComponent.client.tsx
@@ -115,7 +115,6 @@ export default function MapComponent() {
           setSatelliteViewOpen={setSatelliteViewOpen}
           comparisonViewOpen={comparisonViewOpen}
           setComparisonViewOpen={setComparisonViewOpen}
-          period={period}
           setStartDate={setStartDate}
           setEndDate={setEndDate}
           onAddClick={() => setSelectLocation((prev) => !prev)}

--- a/app/components/map/_MapComponent.client.tsx
+++ b/app/components/map/_MapComponent.client.tsx
@@ -119,6 +119,8 @@ export default function MapComponent() {
           setStartDate={setStartDate}
           setEndDate={setEndDate}
           onAddClick={() => setSelectLocation((prev) => !prev)}
+          startDate={startDate}
+          endDate={endDate}
         />
       </MapContainer>
       <Backdrop

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@keyv/memcache": "^2.0.1",
         "@mui/icons-material": "^6.1.6",
         "@mui/material": "^6.1.6",
+        "@mui/x-date-pickers": "^7.22.3",
         "@remix-run/node": "^2.12.1",
         "@remix-run/react": "^2.12.1",
         "@remix-run/serve": "^2.12.1",
@@ -3175,6 +3176,90 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.22.3.tgz",
+      "integrity": "sha512-shNp92IrST5BiVy2f4jbrmRaD32QhyUthjh1Oexvpcn0v6INyuWgxfodoTi5ZCnE5Ue5UVFSs4R9Xre0UbJ5DQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0",
+        "@mui/x-internals": "7.21.0",
+        "@types/react-transition-group": "^4.4.11",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.21.0.tgz",
+      "integrity": "sha512-94YNyZ0BhK5Z+Tkr90RKf47IVCW8R/1MvdUhh6MCQg6sZa74jsX+x+gEZ4kzuCqOsuyTyxikeQ8vVuCIQiP7UQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@keyv/memcache": "^2.0.1",
     "@mui/icons-material": "^6.1.6",
     "@mui/material": "^6.1.6",
+    "@mui/x-date-pickers": "^7.22.3",
     "@remix-run/node": "^2.12.1",
     "@remix-run/react": "^2.12.1",
     "@remix-run/serve": "^2.12.1",


### PR DESCRIPTION
### New additions:

MenuDrawer component
- Drawer is used for screens wider than 600px by Material UI's breakpoints
- SwipeableDrawer is used for small screens (mobile)
- Known issue: opening button functionality needs to be added for small desktop screen (smaller than 600px) to open the drawer as it is currently opened only by mobile touch effects and cannot be clicked open. 
- Known issue: the menu goes on top of the slider
- Known issue: Map drags when menu is opened on mobile with swipe


DatePickers component
- Correct dates can be used with the datepicker component now, and these dates are used with DateSlider component.
- Still need to add functionality to open satellite view with the DatePicker components, currently only sets the dates.
- Known issue: sometimes the dates on the slider do not update correctly. 

custom LayerControl component
- Functionality still missing, currently template with mock data

Other
- added Materia UI Date Pickers as a dependency

### Changes:

- Changed the DateSlider to use correct startDate and endDate instead of Period
- Search bar gives space to menu drawer on desktop view