### PR TITLE
Custom layer control

### DIFF
--- a/app/components/controls/Controls.tsx
+++ b/app/components/controls/Controls.tsx
@@ -8,9 +8,10 @@ import {
 import SearchBar from "./searchbar/SearchBar";
 import Fabs, { type FabsProps } from "./fabs/Fabs";
 import DateSlider from "./slider/DateSlider";
-import { useMemo, useState } from "react";
+import { Dispatch, SetStateAction, useMemo, useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
 import MenuDrawer from "./drawer/Drawer";
+import { LayerKey } from "./layerControl/LayerControl";
 
 export interface ControlsProps {
   setStartDate: (v: Dayjs | null) => void;
@@ -18,6 +19,8 @@ export interface ControlsProps {
   isDrawerOpen: boolean;
   startDate: Dayjs;
   endDate: Dayjs;
+  overlayVisibility: Record<LayerKey, boolean>;
+  setOverlayVisibility: Dispatch<SetStateAction<Record<LayerKey, boolean>>>;
 }
 
 export default function Controls({
@@ -30,6 +33,8 @@ export default function Controls({
   onAddClick,
   startDate,
   endDate,
+  overlayVisibility,
+  setOverlayVisibility,
 }: FabsProps & ControlsProps) {
   // Uses current day by default
   const [sliderValue, setSliderValue] = useState<number | number[]>(
@@ -80,6 +85,8 @@ export default function Controls({
         setEndDate={setEndDate}
         startDate={startDate}
         endDate={endDate}
+        overlayVisibility={overlayVisibility}
+        setOverlayVisibility={setOverlayVisibility}
       />
       <SearchBar isDrawerOpen={isDrawerOpen} isMobile={isMobile} />
       <StyledContainer maxWidth={false}>

--- a/app/components/controls/drawer/Drawer.tsx
+++ b/app/components/controls/drawer/Drawer.tsx
@@ -8,9 +8,10 @@ import {
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import DragHandleRoundedIcon from "@mui/icons-material/DragHandleRounded";
 import { useMap } from "react-leaflet";
-import LayerControl from "../layerControl/LayerControl";
+import LayerControl, { LayerKey } from "../layerControl/LayerControl";
 import DatePickers from "../datePickers/DatePickers";
 import { Dayjs } from "dayjs";
+import { Dispatch, SetStateAction } from "react";
 
 const DrawerWidth = 250;
 const drawerBleeding = 60;
@@ -37,6 +38,8 @@ interface MenuDrawerProps {
   setEndDate: (date: Dayjs | null) => void;
   startDate: Dayjs;
   endDate: Dayjs;
+  overlayVisibility: Record<LayerKey, boolean>;
+  setOverlayVisibility: Dispatch<SetStateAction<Record<LayerKey, boolean>>>;
 }
 
 export default function MenuDrawer({
@@ -47,6 +50,8 @@ export default function MenuDrawer({
   setEndDate,
   startDate,
   endDate,
+  overlayVisibility,
+  setOverlayVisibility,
 }: MenuDrawerProps) {
   // Toggle function to open/close the drawer
   const toggleDrawer = () => {
@@ -102,7 +107,10 @@ export default function MenuDrawer({
               startDate={startDate}
               endDate={endDate}
             />
-            <LayerControl />
+            <LayerControl
+              overlayVisibility={overlayVisibility}
+              setOverlayVisibility={setOverlayVisibility}
+            />
           </Box>
         </SwipeableDrawerStyled>
       ) : (
@@ -157,7 +165,10 @@ export default function MenuDrawer({
               startDate={startDate}
               endDate={endDate}
             />
-            <LayerControl />
+            <LayerControl
+              overlayVisibility={overlayVisibility}
+              setOverlayVisibility={setOverlayVisibility}
+            />
           </Box>
         </SwipeableDrawerStyledDesktop>
       )}

--- a/app/components/controls/layerControl/LayerControl.tsx
+++ b/app/components/controls/layerControl/LayerControl.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { Dispatch, SetStateAction } from "react";
 import { List, ListItem, Checkbox, Box, Typography } from "@mui/material";
 
 // Mock data: array of layer options
@@ -8,18 +8,14 @@ const layerOptions = [
   { key: "conservation", name: "Suojelualueet" },
 ] as const;
 
-type LayerKey = (typeof layerOptions)[number]["key"];
+export type LayerKey = (typeof layerOptions)[number]["key"];
 
-export default function LayerControl() {
-  //TODO move this to the map component
-  const [overlayVisibility, setOverlayVisibility] = useState<
-    Record<LayerKey, boolean>
-  >({
-    sightings: false,
-    observations: false,
-    conservation: false,
-  });
+interface LayerControlProps {
+  overlayVisibility: Record<LayerKey, boolean>;
+  setOverlayVisibility: Dispatch<SetStateAction<Record<LayerKey, boolean>>>;
+}
 
+export default function LayerControl({ overlayVisibility, setOverlayVisibility }: LayerControlProps) {
   // Toggle layer
   const handleCheckboxChange = (key: LayerKey) => {
     setOverlayVisibility((prevState) => ({

--- a/app/components/controls/layerControl/LayerControl.tsx
+++ b/app/components/controls/layerControl/LayerControl.tsx
@@ -15,7 +15,10 @@ interface LayerControlProps {
   setOverlayVisibility: Dispatch<SetStateAction<Record<LayerKey, boolean>>>;
 }
 
-export default function LayerControl({ overlayVisibility, setOverlayVisibility }: LayerControlProps) {
+export default function LayerControl({
+  overlayVisibility,
+  setOverlayVisibility,
+}: LayerControlProps) {
   // Toggle layer
   const handleCheckboxChange = (key: LayerKey) => {
     setOverlayVisibility((prevState) => ({

--- a/app/components/map/_MapComponent.client.tsx
+++ b/app/components/map/_MapComponent.client.tsx
@@ -9,7 +9,6 @@ the window object and DOM elements.
 */
 
 import {
-  LayersControl,
   MapContainer,
   TileLayer,
   WMSTileLayer,
@@ -28,6 +27,7 @@ import ReportCreator from "../observations/ReportCreator";
 import type { LatLng } from "leaflet";
 import { Backdrop, Typography } from "@mui/material";
 import { Sighting } from "~/routes/lajidata";
+import { LayerKey } from "../controls/layerControl/LayerControl";
 
 export default function MapComponent() {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -42,6 +42,13 @@ export default function MapComponent() {
   const [reportLocation, setReportLocation] = useState<LatLng | null>(null);
   const [selectLocation, setSelectLocation] = useState(false);
   const [sightings, setSightings] = useState<Sighting[]>([]);
+  const [overlayVisibility, setOverlayVisibility] = useState<
+    Record<LayerKey, boolean>
+  >({
+    sightings: true,
+    observations: false,
+    conservation: false,
+  });
 
   interface WMSParams {
     attribution: string;
@@ -105,11 +112,9 @@ export default function MapComponent() {
             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           />
         )}
-        <LayersControl position="topright">
-          <SpeciesLayer data={sightings} />
-          <ReportLayer />
-          <ConservationLayer />
-        </LayersControl>
+        {overlayVisibility.sightings && <SpeciesLayer data={sightings} />}
+        {overlayVisibility.observations && <ReportLayer />}
+        {overlayVisibility.conservation && <ConservationLayer />}
         <Controls
           satelliteViewOpen={satelliteViewOpen}
           setSatelliteViewOpen={setSatelliteViewOpen}
@@ -120,6 +125,8 @@ export default function MapComponent() {
           onAddClick={() => setSelectLocation((prev) => !prev)}
           startDate={startDate}
           endDate={endDate}
+          overlayVisibility={overlayVisibility}
+          setOverlayVisibility={setOverlayVisibility}
         />
       </MapContainer>
       <Backdrop

--- a/app/components/map/_MapComponent.client.tsx
+++ b/app/components/map/_MapComponent.client.tsx
@@ -45,7 +45,7 @@ export default function MapComponent() {
   const [overlayVisibility, setOverlayVisibility] = useState<
     Record<LayerKey, boolean>
   >({
-    sightings: true,
+    sightings: false,
     observations: false,
     conservation: false,
   });

--- a/app/components/map/_MapComponent.client.tsx
+++ b/app/components/map/_MapComponent.client.tsx
@@ -8,11 +8,7 @@ component to be rendered on the client side so that Leaflet can access
 the window object and DOM elements.
 */
 
-import {
-  MapContainer,
-  TileLayer,
-  WMSTileLayer,
-} from "react-leaflet";
+import { MapContainer, TileLayer, WMSTileLayer } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import Controls from "~/components/controls/Controls";
 import SpeciesLayer from "./layers/SpeciesLayer";

--- a/app/components/map/layers/ConservationLayer.tsx
+++ b/app/components/map/layers/ConservationLayer.tsx
@@ -1,8 +1,8 @@
-import { LayersControl, WMSTileLayer } from "react-leaflet";
+import { LayerGroup, WMSTileLayer } from "react-leaflet";
 
 export default function ConservationLayer() {
   return (
-    <LayersControl.Overlay name="Conservation layer">
+    <LayerGroup>
       <WMSTileLayer
         url="https://paikkatiedot.ymparisto.fi/geoserver/syke_luonnonsuojeluohjelma_alueet/wms"
         layers="Luonnonsuojeluohjelmaalueet"
@@ -10,6 +10,6 @@ export default function ConservationLayer() {
         transparent={true}
         opacity={0.33}
       />
-    </LayersControl.Overlay>
+    </LayerGroup>
   );
 }

--- a/app/components/map/layers/ReportLayer.tsx
+++ b/app/components/map/layers/ReportLayer.tsx
@@ -1,4 +1,4 @@
-import { LayersControl } from "react-leaflet";
+import { LayerGroup } from "react-leaflet";
 import CustomMarker from "~/components/map/markers/CustomMarker";
 import MarkerClusterGroup from "react-leaflet-cluster";
 import ObservationPopup from "~/components/observations/ObservationPopup";
@@ -45,7 +45,7 @@ export default function ReportLayer() {
   ];
 
   return (
-    <LayersControl.Overlay name="Reports layer">
+    <LayerGroup>
       <MarkerClusterGroup>
         {reports.map((r, index) => (
           <CustomMarker key={index} position={[r.longitude, r.latitude]}>
@@ -53,6 +53,6 @@ export default function ReportLayer() {
           </CustomMarker>
         ))}
       </MarkerClusterGroup>
-    </LayersControl.Overlay>
+    </LayerGroup>
   );
 }

--- a/app/components/map/layers/SpeciesLayer.tsx
+++ b/app/components/map/layers/SpeciesLayer.tsx
@@ -1,4 +1,4 @@
-import { LayersControl } from "react-leaflet";
+import { LayerGroup } from "react-leaflet";
 import CustomMarker from "~/components/map/markers/CustomMarker";
 import MarkerClusterGroup from "react-leaflet-cluster";
 import { Sighting } from "~/routes/lajidata";
@@ -10,7 +10,7 @@ interface SpeciesLayerProps {
 
 export default function SpeciesLayer({ data }: SpeciesLayerProps) {
   return (
-    <LayersControl.Overlay name="Species layer">
+    <LayerGroup>
       <MarkerClusterGroup>
         {data &&
           data.map((s, index) => (
@@ -23,6 +23,6 @@ export default function SpeciesLayer({ data }: SpeciesLayerProps) {
             </CustomMarker>
           ))}
       </MarkerClusterGroup>
-    </LayersControl.Overlay>
+    </LayerGroup>
   );
 }


### PR DESCRIPTION
### Changes
- `MapComponent` holds `overlayVisibility`-state that is passed down all the way to `LayerControl`-component.
- Overlays can now be selected via the drawer menu.