### PR TITLE
Satellite fetch fix

### DIFF
--- a/app/components/controls/Controls.tsx
+++ b/app/components/controls/Controls.tsx
@@ -133,7 +133,6 @@ export default function Controls({
   ) => {
     setSliderValue(value);
     debounceSliderInput(value);
-
   };
 
   return (

--- a/app/components/controls/Controls.tsx
+++ b/app/components/controls/Controls.tsx
@@ -121,7 +121,7 @@ export default function Controls({
           setStartDate(dayjs(value[0]));
           setEndDate(dayjs(value[1]));
         } else {
-          setEndDate(dayjs(value));
+          setStartDate(dayjs(value));
         }
       }, 400),
     [setEndDate, setStartDate],
@@ -133,6 +133,7 @@ export default function Controls({
   ) => {
     setSliderValue(value);
     debounceSliderInput(value);
+
   };
 
   return (

--- a/app/components/controls/datePickers/DatePickers.tsx
+++ b/app/components/controls/datePickers/DatePickers.tsx
@@ -48,7 +48,6 @@ export default function DatePickers({
       setPeriod({ start: dayjs("2015-10-10"), end: dayjs() });
       setStartDateError(null);
       setEndDateError(null);
-
     }
 
     if (comparisonViewOpen === true && startDate && endDate) {
@@ -61,7 +60,6 @@ export default function DatePickers({
     startDate,
     setSliderValue,
     setPeriod,
-
   ]);
 
   const handleStartDateChange = (newValue: Dayjs | null) => {

--- a/app/components/controls/datePickers/DatePickers.tsx
+++ b/app/components/controls/datePickers/DatePickers.tsx
@@ -45,6 +45,10 @@ export default function DatePickers({
     if (satelliteViewOpen === false) {
       setLocalStartDate(null);
       setLocalEndDate(null);
+      setPeriod({ start: dayjs("2015-10-10"), end: dayjs() });
+      setStartDateError(null);
+      setEndDateError(null);
+
     }
 
     if (comparisonViewOpen === true && startDate && endDate) {
@@ -56,14 +60,17 @@ export default function DatePickers({
     endDate,
     startDate,
     setSliderValue,
+    setPeriod,
+
   ]);
+
   const handleStartDateChange = (newValue: Dayjs | null) => {
     // Set the local state and the start date state.
     setLocalStartDate(newValue);
     setStartDate(newValue);
 
     // If the end date is set and the new start date is after the end date, set an error.
-    if (newValue && endDate && newValue.isAfter(endDate)) {
+    if (newValue && endDate && newValue.isAfter(localEndDate)) {
       const error = t("startDateError");
       setStartDateError(error);
     } else {
@@ -74,8 +81,9 @@ export default function DatePickers({
     // If the incoming value is not null, set the period state and the slider value.
     if (newValue) {
       setPeriod((prev) => ({ ...prev, start: newValue }));
-      setSliderValue([newValue.valueOf()]);
+      setSliderValue(newValue.valueOf());
       setSatelliteViewOpen(true);
+      setStartDate(newValue);
     }
 
     // If the incoming value is null, set the start date state and
@@ -86,7 +94,7 @@ export default function DatePickers({
       setComparisonViewOpen(false);
       setEndDate(dayjs());
       setLocalEndDate(null);
-      setSliderValue([dayjs().valueOf()]);
+      setSliderValue(dayjs().valueOf());
       setPeriod((prev) => ({ ...prev, start: dayjs("2015-10-10") }));
     }
   };
@@ -98,7 +106,7 @@ export default function DatePickers({
 
     // If the start date is set and the new end date is before the start date,
     //set an error.
-    if (startDate && newValue && newValue.isBefore(startDate)) {
+    if (startDate && newValue && newValue.isBefore(localStartDate)) {
       const error = t("endDateError");
       setEndDateError(error);
     } else {
@@ -116,13 +124,14 @@ export default function DatePickers({
     // Update period state and set the slider value.
     if (newValue != null) {
       setPeriod((prev) => ({ ...prev, end: newValue }));
-      setEndDate(dayjs());
+      setEndDate(newValue);
     } else {
       setPeriod((prev) => ({ ...prev, end: dayjs() }));
       setComparisonViewOpen(false);
+      setEndDate(dayjs());
 
       if (startDate) {
-        setSliderValue([startDate.valueOf()]);
+        setSliderValue(startDate.valueOf());
       }
     }
   };

--- a/app/components/controls/fabs/Fabs.tsx
+++ b/app/components/controls/fabs/Fabs.tsx
@@ -133,7 +133,6 @@ export default function Fabs({
 
       return newState;
     });
-
   };
 
   const map = useMapEvent("locationfound", (event) => {

--- a/app/components/controls/fabs/Fabs.tsx
+++ b/app/components/controls/fabs/Fabs.tsx
@@ -123,6 +123,22 @@ export default function Fabs({
     });
   };
 
+  const handleSatelliteViewChange = () => {
+    setSatelliteViewOpen((prev) => {
+      const newState = !prev;
+
+      if (!newState) {
+        setComparisonViewOpen(false);
+      }
+
+      return newState;
+    });
+
+    handleCompareViewChange();
+
+      
+  };
+
   const map = useMapEvent("locationfound", (event) => {
     map.flyTo(event.latlng, 16);
     setUserLocation(event.latlng);
@@ -145,7 +161,7 @@ export default function Fabs({
       <StyledToggleButton
         value="check"
         selected={satelliteViewOpen}
-        onChange={() => setSatelliteViewOpen(!satelliteViewOpen)}
+        onChange={handleSatelliteViewChange}
       >
         <SatelliteAltIcon />
       </StyledToggleButton>

--- a/app/components/controls/fabs/Fabs.tsx
+++ b/app/components/controls/fabs/Fabs.tsx
@@ -135,8 +135,6 @@ export default function Fabs({
     });
 
     handleCompareViewChange();
-
-      
   };
 
   const map = useMapEvent("locationfound", (event) => {

--- a/app/components/controls/fabs/Fabs.tsx
+++ b/app/components/controls/fabs/Fabs.tsx
@@ -134,7 +134,6 @@ export default function Fabs({
       return newState;
     });
 
-    handleCompareViewChange();
   };
 
   const map = useMapEvent("locationfound", (event) => {

--- a/app/components/map/_MapComponent.client.tsx
+++ b/app/components/map/_MapComponent.client.tsx
@@ -161,7 +161,7 @@ export default function MapComponent() {
               attribution='&copy; <a href="https://dataspace.copernicus.eu/" target="_blank">Copernicus Data Space Ecosystem</a>'
               url="/wms"
               layers="TRUE_COLOR"
-              time={dayjs(endDate).format("YYYY-MM-DD")}
+              time={dayjs(startDate).format("YYYY-MM-DD")}
             />
           )
         ) : (


### PR DESCRIPTION
Bug fixes related to slider values and dates. 

- state changes to various components
- added additional  state changes to DatePickers
- changed the logic of using the `startdate` as slidervalue in single satellite image view rather than using the`endDate`. With this, issue #131  is now fixed. 
- Changed some of the error message logic to prevent unnecessary error messages if user toggles the satellite view many times in a row. 